### PR TITLE
chore(naming-syntax): Made variables.tf readable, added environment v…

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@ No modules.
 | <a name="input_enable_public_ip"></a> [enable\_public\_ip](#input\_enable\_public\_ip) | n/a | `bool` | `false` | no |
 | <a name="input_enable_s3_logs"></a> [enable\_s3\_logs](#input\_enable\_s3\_logs) | n/a | `bool` | `true` | no |
 | <a name="input_enable_ssh_fallback"></a> [enable\_ssh\_fallback](#input\_enable\_ssh\_fallback) | n/a | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | n/a | `string` | `"dev"` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | n/a | `string` | `"t3.micro"` | no |
 | <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | n/a | `number` | `90` | no |
-| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | n/a | `string` | n/a | yes |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | n/a | `string` | `"bastion"` | no |
 | <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | n/a | `list(string)` | n/a | yes |
 | <a name="input_public_subnet_id"></a> [public\_subnet\_id](#input\_public\_subnet\_id) | n/a | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -1,20 +1,36 @@
-variable "name_prefix" { type = string }
+variable "name_prefix" {
+  type    = string
+  default = "bastion"
+}
 
 variable "tags" {
   type    = map(string)
   default = {}
 }
 
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+
 # Network
-variable "vpc_id" { type = string }
+variable "vpc_id" {
+  type = string
+}
 
-variable "public_subnet_id" { type = string }
+variable "public_subnet_id" {
+  type = string
+}
 
-variable "private_subnet_ids" { type = list(string) }
+variable "private_subnet_ids" {
+  type = list(string)
+}
+
 variable "allowed_cidrs" {
   type    = list(string)
   default = []
 }
+
 variable "allowed_ssh_cidrs" {
   type    = list(string)
   default = []
@@ -45,19 +61,25 @@ variable "create_vpc_endpoints" {
 }
 
 # Bastion specifics
-variable "ami_id" { type = string }
+variable "ami_id" {
+  type = string
+}
+
 variable "instance_type" {
   type    = string
   default = "t3.micro"
 }
+
 variable "enable_public_ip" {
   type    = bool
   default = false
 }
+
 variable "enable_ssh_fallback" {
   type    = bool
   default = false
 }
+
 variable "attach_admin_policy" {
   type    = bool
   default = true


### PR DESCRIPTION
This pull request introduces an `environment` variable to enable environment-specific naming for resources and updates several default values to improve usability. The changes primarily focus on enhancing resource naming conventions and simplifying variable configurations.

### Enhancements to Resource Naming:

* Updated resource names in `main.tf` to include the new `environment` variable, enabling environment-specific prefixes for AWS resources such as CloudWatch log groups, S3 buckets, IAM roles, and security groups. (`main.tf`: [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL38-R52) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL71-R71) [[3]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL112-R112) [[4]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL135-R135) [[5]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL155-R155)

### Improvements to Variable Configuration:

* Added a new `environment` variable in `variables.tf` with a default value of `"dev"`. This variable is used to distinguish resources across different environments. (`variables.tf`: [variables.tfL1-R33](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL1-R33))
* Updated the `name_prefix` variable to have a default value of `"bastion"`, reducing the need for manual configuration. (`variables.tf`: [variables.tfL1-R33](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL1-R33))

### Documentation Updates:

* Modified `README.md` to reflect the new `environment` variable and updated the default value for `name_prefix`. (`README.md`: [README.mdR117-R120](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R117-R120))